### PR TITLE
Mark website as stale with maintenance banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,9 @@
 	<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
 		<a class="navbar-brand mx-auto" href="/cowin">CoWIN Vaccine Booking</a>
 	</nav>
+	<div class="alert alert-warning stale-banner" role="alert">
+		<strong>Stale project notice:</strong> This website is no longer actively maintained and may not work with the latest CoWIN API changes.
+	</div>
 	<div class="container d-flex flex-row flex-wrap mt-5 pt-4">
 		<div class="form-group p-1">
 			<div class="input-group">


### PR DESCRIPTION
### Motivation
- Make it clear to visitors that the site is no longer actively maintained and may break due to CoWIN API changes.

### Description
- Add a Bootstrap warning alert directly below the navbar in `index.html` containing a short "Stale project notice" message to inform users the project is not actively maintained.

### Testing
- Ran `git diff --check` which passed, and attempted to serve the site with `python3 -m http.server` and capture a screenshot with Playwright but the headless Chromium crashed (SIGSEGV) so no screenshot was produced; the HTML change is committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32914fa608328a8925f995a5e67f0)