### PR TITLE
Add stale-project warning banner to homepage

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -29,3 +29,6 @@ footer {
     color: lightblue;
     font-weight: bold;
 }
+.stale-banner {
+    margin-top: 4.5rem;
+}

--- a/index.html
+++ b/index.html
@@ -29,6 +29,9 @@
 	<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
 		<a class="navbar-brand mx-auto" href="/cowin">CoWIN Vaccine Booking</a>
 	</nav>
+	<div class="alert alert-warning stale-banner" role="alert">
+		<strong>Stale project notice:</strong> This website is no longer actively maintained and may not work with the latest CoWIN API changes.
+	</div>
 	<div class="container d-flex flex-row flex-wrap mt-5 pt-4">
 		<div class="form-group p-1">
 			<div class="input-group">


### PR DESCRIPTION
### Motivation
- Provide a clear notice on the homepage that the site is no longer actively maintained and may not work with the latest CoWIN API changes.

### Description
- Added a Bootstrap warning alert (`alert alert-warning stale-banner`) under the fixed navbar in `index.html` with the stale-project message, and added a `.stale-banner` rule to `css/styles.css` to adjust spacing.

### Testing
- No automated tests were added or executed for this small UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32914fa608328a8925f995a5e67f0)